### PR TITLE
Fix code scanning alert #19: Missing regular expression anchor

### DIFF
--- a/first.js
+++ b/first.js
@@ -2066,7 +2066,7 @@ app.get('/some/path', function(req, res) {
     let url = req.param('url'),
         host = urlLib.parse(url).host;
     // BAD: the host of `url` may be controlled by an attacker
-    let regex = /^((www|beta)\.)?example\.com/;
+    let regex = /^((www|beta)\.)?example\.com$/;
     if (host.match(regex)) {
         res.redirect(url);
     }
@@ -2080,7 +2080,7 @@ app.get('/some/path', function(req, res) {
     let url = req.param('url'),
         host = urlLib.parse(url).host;
     // BAD: the host of `url` may be controlled by an attacker
-    let regex = /^((www|beta)\.)?example\.com/;
+    let regex = /^((www|beta)\.)?example\.com$/;
     if (host.match(regex)) {
         res.redirect(url);
     }


### PR DESCRIPTION
Fixes [https://github.com/dsp-testing/alona-public/security/code-scanning/19](https://github.com/dsp-testing/alona-public/security/code-scanning/19)

_Suggested fixes for CodeQL alerts, powered by Copilot Autofix. Review carefully before merging._
