### PR TITLE
Fix code scanning alert #19: Missing regular expression anchor

### DIFF
--- a/first.js
+++ b/first.js
@@ -2066,7 +2066,7 @@ app.get('/some/path', function(req, res) {
     let url = req.param('url'),
         host = urlLib.parse(url).host;
     // BAD: the host of `url` may be controlled by an attacker
-    let regex = /^((www|beta)\.)?example\.com/;
+    let regex = /^((www|beta)\.)?example\.com$/;
     if (host.match(regex)) {
         res.redirect(url);
     }
@@ -2080,7 +2080,7 @@ app.get('/some/path', function(req, res) {
     let url = req.param('url'),
         host = urlLib.parse(url).host;
     // BAD: the host of `url` may be controlled by an attacker
-    let regex = /^((www|beta)\.)?example\.com/;
+    let regex = /^((www|beta)\.)?example\.com$/;
     if (host.match(regex)) {
         res.redirect(url);
     }


### PR DESCRIPTION
Fixes [https://github.com/dsp-testing/alona-public/security/code-scanning/19](https://github.com/dsp-testing/alona-public/security/code-scanning/19)

**Copilot generated AI autofix description:**
To fix the problem, we need to ensure that the regular expression matches the entire hostname and not just a prefix. This can be achieved by adding the $ anchor at the end of the regular expression. This change will ensure that the regular expression only matches strings that exactly match the specified pattern, without any additional characters at the end.

- General fix: Add the $ anchor at the end of the regular expression to ensure it matches the entire string.
- Detailed fix: Modify the regular expression on lines 2069 and 2083 to include the $ anchor at the end.
- Files/regions/lines to change: The changes will be made in the file first.js on lines 2069 and 2083.
- Needed: No additional methods, imports, or definitions are required to implement this change.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
