### PR TITLE
Fix code scanning alert no. 20: Missing regular expression anchor

### DIFF
--- a/first.js
+++ b/first.js
@@ -2080,7 +2080,7 @@ app.get('/some/path', function(req, res) {
     let url = req.param('url'),
         host = urlLib.parse(url).host;
     // BAD: the host of `url` may be controlled by an attacker
-    let regex = /^((www|beta)\.)?example\.com/;
+    let regex = /^((www|beta)\.)?example\.com$/;
     if (host.match(regex)) {
         res.redirect(url);
     }


### PR DESCRIPTION
Fixes [https://github.com/dsp-testing/alona-public/security/code-scanning/20](https://github.com/dsp-testing/alona-public/security/code-scanning/20)

To fix the problem, we need to ensure that the regular expression matches the entire hostname and not just a part of it. This can be achieved by adding an end anchor (`$`) to the regular expression. This change will ensure that the regular expression only matches the exact subdomains of `example.com` and not any other unintended domains.

- Locate the regular expression `/^((www|beta)\.)?example\.com/` in the file `first.js`.
- Modify the regular expression to include an end anchor (`$`), changing it to `/^((www|beta)\.)?example\.com$/`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
