### PR TITLE
Fix code scanning alert no. 3: Server-side URL redirect

### DIFF
--- a/first.js
+++ b/first.js
@@ -1,3 +1,4 @@
+const urlLib = require('url');
 document.write(window.location.search);
 /*
 This ^^ causes an alert that won't be reported in the PR because
@@ -1111,6 +1112,16 @@ t.test('automatic provenance with incorrect permissions', async t => {
 })
 
 
+function isLocalUrl(path) {
+    try {
+        return (
+            new URL(path, "https://example.com").origin === "https://example.com"
+        );
+    } catch (e) {
+        return false;
+    }
+}
+
 // It's a classic:
 let userInput = document.createElement('div');
 userInput.textContent = window.location.search;
@@ -1118,12 +1129,11 @@ document.body.appendChild(userInput);
 
 // Here's a different one
 app.get('/some/path', function(req, res) {
-    let url = req.param('url'),
-        host = urlLib.parse(url).host;
-    // BAD: the host of `url` may be controlled by an attacker
-    let regex = /^((www|beta)\.)?example\.com/;
-    if (host.match(regex)) {
+    let url = req.param('url');
+    if (isLocalUrl(url)) {
         res.redirect(url);
+    } else {
+        res.redirect('/');
     }
 });
 
@@ -1132,12 +1142,11 @@ document.write(encodeURI(window.location.search));
 
 // Here's a different one
 app.get('/some/path', function(req, res) {
-    let url = req.param('url'),
-        host = urlLib.parse(url).host;
-    // BAD: the host of `url` may be controlled by an attacker
-    let regex = /^((www|beta)\.)?example\.com/;
-    if (host.match(regex)) {
+    let url = req.param('url');
+    if (isLocalUrl(url)) {
         res.redirect(url);
+    } else {
+        res.redirect('/');
     }
 });
 


### PR DESCRIPTION
Fixes [https://github.com/dsp-testing/alona-public/security/code-scanning/3](https://github.com/dsp-testing/alona-public/security/code-scanning/3)

To fix the problem, we need to ensure that the URL provided by the user is validated against a list of known, safe URLs or domains. This can be achieved by maintaining a whitelist of allowed URLs or by ensuring that the URL does not redirect to a different host. In this case, we will implement a function to check that the URL is local to the application’s domain.

1. Create a function `isLocalUrl` to validate that the URL does not redirect to a different host.
2. Use this function to validate the `url` parameter before performing the redirection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
