### PR TITLE
Fix code scanning alert no. 18: Missing regular expression anchor

### DIFF
--- a/first.js
+++ b/first.js
@@ -1136,7 +1136,7 @@ app.get('/some/path', function(req, res) {
     let url = req.param('url'),
         host = urlLib.parse(url).host;
     // BAD: the host of `url` may be controlled by an attacker
-    let regex = /^((www|beta)\.)?example\.com/;
+    let regex = /^((www|beta)\.)?example\.com$/;
     if (host.match(regex)) {
         res.redirect(url);
     }


### PR DESCRIPTION
Fixes [https://github.com/dsp-testing/alona-public/security/code-scanning/18](https://github.com/dsp-testing/alona-public/security/code-scanning/18)

To fix the problem, we need to ensure that the regular expression matches the entire hostname and does not allow any additional characters after `example.com`. This can be achieved by adding an end anchor (`$`) to the regular expression. This change will ensure that the regular expression only matches the intended subdomains and does not allow any additional malicious content.

- Update the regular expression on line 1139 to include an end anchor (`$`).
- Ensure that the regular expression matches the entire hostname by adding the `$` at the end.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
