### PR TITLE
Fix code scanning alert no. 3: Server-side URL redirect

### DIFF
--- a/first.js
+++ b/first.js
@@ -1,3 +1,5 @@
+const urlLib = require('url');
+
 document.write(window.location.search);
 /*
 This ^^ causes an alert that won't be reported in the PR because
@@ -1117,6 +1119,16 @@ let userInput = document.createElement('div');
 userInput.textContent = window.location.search;
 document.body.appendChild(userInput);
 
+function isLocalUrl(path) {
+    try {
+        return (
+            new URL(path, "https://example.com").origin === "https://example.com"
+        );
+    } catch (e) {
+        return false;
+    }
+}
+
 // Here's a different one
 app.get('/some/path', function(req, res) {
     let url = req.param('url'),
@@ -1133,12 +1145,11 @@ document.write(encodeURI(window.location.search));
 
 // Here's a different one
 app.get('/some/path', function(req, res) {
-    let url = req.param('url'),
-        host = urlLib.parse(url).host;
-    // BAD: the host of `url` may be controlled by an attacker
-    let regex = /^((www|beta)\.)?example\.com/;
-    if (host.match(regex)) {
+    let url = req.param('url');
+    if (isLocalUrl(url)) {
         res.redirect(url);
+    } else {
+        res.redirect('/');
     }
 });
 


### PR DESCRIPTION
Fixes [https://github.com/dsp-testing/alona-public/security/code-scanning/3](https://github.com/dsp-testing/alona-public/security/code-scanning/3)

To fix the problem, we need to ensure that the redirection only occurs to trusted URLs. We can achieve this by maintaining a list of authorized redirects and validating the user input against this list. Alternatively, we can ensure that the target URL does not redirect to a different host by verifying that the host stays the same.

The best way to fix the problem without changing existing functionality is to implement a function that checks if the URL is local or belongs to a trusted domain. We will use the `URL` constructor to parse the URL and compare its origin with the trusted origin.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
